### PR TITLE
fix(gitignore): anchor target/ so it stops swallowing source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,10 @@ dist
 dist-ssr
 *.local
 
-# Rust build artifacts
+# Rust build artifacts (anchored: an unanchored `target/` also matches source
+# directories named `target` at any depth, e.g. usage_switch/target/).
 src-tauri/target/
-target/
+/target/
 
 # Cargo workspace owns one lockfile at the repository root.
 **/Cargo.lock

--- a/crates/skillstar-app/src/usage_switch/target/codex.rs
+++ b/crates/skillstar-app/src/usage_switch/target/codex.rs
@@ -1,0 +1,179 @@
+//! Codex CLI: `~/.codex/auth.json` (honouring `CODEX_HOME`) plus, on macOS,
+//! the keychain entry the CLI actually prefers.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::{Map, Value};
+use skillstar_usage::crypto;
+use skillstar_usage::oauth::token_refresh;
+use skillstar_usage::subscription::Subscription;
+
+use super::super::error::{CustodyError, CustodyResult, ExternalStoreError, MaterializeError};
+use super::{AccountIdentity, CliCredentialTarget, identity_from_jwt, secret};
+
+/// What the user calls this CLI, for messages the user reads.
+const TOOL: &str = "Codex";
+
+/// Every "you have to log in again" message for this CLI ends the same way.
+const REMEDY: &str = "请重新登录该账号补充凭证";
+
+pub(in crate::usage_switch) struct CodexTarget;
+
+impl CliCredentialTarget for CodexTarget {
+    fn catalog_id(&self) -> &'static str {
+        "codex"
+    }
+
+    fn tool_id(&self) -> &'static str {
+        "codex"
+    }
+
+    fn live_path(&self) -> CustodyResult<PathBuf> {
+        skillstar_models::tool_sync::resolve_codex_auth_path().map_err(|error| {
+            CustodyError::ResolveLivePath {
+                tool: TOOL,
+                detail: error.to_string(),
+            }
+        })
+    }
+
+    fn access_token(&self, root: &Value) -> Option<String> {
+        root.get("tokens")
+            .and_then(|tokens| tokens.get("access_token"))
+            .and_then(Value::as_str)
+            .or_else(|| root.get("OPENAI_API_KEY").and_then(Value::as_str))
+            .filter(|token| !token.is_empty())
+            .map(str::to_string)
+    }
+
+    /// `auth.json` carries no expiry field of its own; the access token's JWT
+    /// `exp` is the only clock, and API-key mode has none at all.
+    fn expires_at(&self, root: &Value) -> Option<i64> {
+        token_refresh::jwt_exp(&self.access_token(root)?)
+    }
+
+    fn identity(&self, root: &Value) -> AccountIdentity {
+        let tokens = root.get("tokens");
+        let mut identity = tokens
+            .and_then(|t| t.get("id_token"))
+            .and_then(Value::as_str)
+            .map(identity_from_jwt)
+            .unwrap_or_default();
+        if identity.is_empty() {
+            identity = self
+                .access_token(root)
+                .map(|token| identity_from_jwt(&token))
+                .unwrap_or_default();
+        }
+        if identity.is_empty() {
+            identity.push_subject(
+                tokens
+                    .and_then(|t| t.get("account_id"))
+                    .and_then(Value::as_str),
+            );
+        }
+        identity
+    }
+
+    /// Mirrors the schema the real CLI writes:
+    /// `{ OPENAI_API_KEY, tokens{ id_token, access_token, refresh_token,
+    /// account_id }, last_refresh }`. Unknown keys in `base` survive.
+    fn materialize(
+        &self,
+        sub: &Subscription,
+        base: Option<&Value>,
+    ) -> Result<Value, MaterializeError> {
+        let mut root = base
+            .and_then(Value::as_object)
+            .cloned()
+            .unwrap_or_else(Map::new);
+
+        if let Some(api_key) = secret(sub.api_key_encrypted.as_deref()) {
+            root.insert("OPENAI_API_KEY".into(), Value::String(api_key));
+            // An API key and an OAuth session are different logins; leaving
+            // the old token block would let the CLI keep using it.
+            root.remove("tokens");
+            return Ok(Value::Object(root));
+        }
+
+        let missing = |field| MaterializeError::MissingSecret {
+            tool: TOOL,
+            field,
+            remedy: REMEDY,
+        };
+        let access_token =
+            secret(sub.access_token_encrypted.as_deref()).ok_or_else(|| missing("access_token"))?;
+        let id_token =
+            secret(sub.id_token_encrypted.as_deref()).ok_or_else(|| missing("id_token"))?;
+
+        let tokens = serde_json::json!({
+            "id_token": id_token,
+            "access_token": access_token,
+            "refresh_token": secret(sub.refresh_token_encrypted.as_deref()).unwrap_or_default(),
+            "account_id": sub.oauth_account_id,
+        });
+        root.insert("OPENAI_API_KEY".into(), Value::Null);
+        root.insert("tokens".into(), tokens);
+        root.insert(
+            "last_refresh".into(),
+            Value::String(
+                chrono::Utc::now()
+                    .format("%Y-%m-%dT%H:%M:%S%.6fZ")
+                    .to_string(),
+            ),
+        );
+        Ok(Value::Object(root))
+    }
+
+    fn absorb(&self, root: &Value, sub: &mut Subscription) {
+        let Some(tokens) = root.get("tokens") else {
+            if let Some(key) = root.get("OPENAI_API_KEY").and_then(Value::as_str) {
+                sub.api_key_encrypted = Some(crypto::encrypt(key));
+            }
+            return;
+        };
+        let field = |name: &str| {
+            tokens
+                .get(name)
+                .and_then(Value::as_str)
+                .filter(|v| !v.is_empty())
+        };
+        if let Some(access) = field("access_token") {
+            sub.access_token_encrypted = Some(crypto::encrypt(access));
+            sub.access_token_expires_at = token_refresh::jwt_exp(access);
+        }
+        sub.refresh_token_encrypted = field("refresh_token").map(crypto::encrypt);
+        if let Some(id_token) = field("id_token") {
+            sub.id_token_encrypted = Some(crypto::encrypt(id_token));
+        }
+        if let Some(account_id) = field("account_id") {
+            sub.oauth_account_id = Some(account_id.to_string());
+        }
+        sub.requires_reauth = false;
+    }
+
+    fn external_root(&self, live: &Path) -> Option<Value> {
+        #[cfg(target_os = "macos")]
+        {
+            super::super::keychain::read(live.parent()?)
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            let _ = live;
+            None
+        }
+    }
+
+    fn publish_external(&self, live: &Path, root: &Value) -> Result<bool, ExternalStoreError> {
+        #[cfg(target_os = "macos")]
+        {
+            let home = live.parent().ok_or(ExternalStoreError::MissingCodexHome)?;
+            super::super::keychain::write_merged(home, root)
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            let _ = (live, root);
+            Ok(false)
+        }
+    }
+}

--- a/crates/skillstar-app/src/usage_switch/target/grok.rs
+++ b/crates/skillstar-app/src/usage_switch/target/grok.rs
@@ -1,0 +1,348 @@
+//! Grok CLI: `~/.grok/auth.json` (honouring `GROK_HOME`), a JSON object keyed
+//! by OIDC scope URL, plus the official `auth.json.lock` the CLI itself takes
+//! while rotating tokens.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use serde_json::{Map, Value};
+use skillstar_usage::crypto;
+use skillstar_usage::oauth::token_refresh;
+use skillstar_usage::subscription::Subscription;
+
+use super::super::error::{CustodyError, CustodyResult, MaterializeError};
+use super::{
+    AccountIdentity, CliCredentialTarget, secret, subscription_expiry, subscription_identity,
+};
+
+/// What the user calls this CLI, for messages the user reads. `tool_id` stays
+/// lowercase because the UI keys off it.
+const TOOL: &str = "Grok";
+
+/// Scopes the Grok CLI itself requires. A token holding only `api:access`
+/// authenticates for billing but makes every CLI call fail, so writing one
+/// would look like a successful switch and behave like a broken login.
+const REQUIRED_CLI_SCOPES: [&str; 3] = [
+    "grok-cli:access",
+    "conversations:read",
+    "conversations:write",
+];
+
+/// Claims the CLI expects to find mirrored onto the entry itself.
+const MIRRORED_CLAIMS: [&str; 11] = [
+    "email",
+    "user_id",
+    "principal_id",
+    "principal_type",
+    "team_id",
+    "team_name",
+    "team_role",
+    "subscription_tier",
+    "first_name",
+    "last_name",
+    "profile_image_asset_id",
+];
+
+pub(in crate::usage_switch) struct GrokTarget;
+
+fn scope_key() -> String {
+    format!(
+        "https://auth.x.ai::{}",
+        skillstar_usage::fetchers::oauth::xai::client_id()
+    )
+}
+
+impl GrokTarget {
+    fn entry<'a>(&self, root: &'a Value) -> Option<&'a Value> {
+        root.get(scope_key())
+    }
+}
+
+impl CliCredentialTarget for GrokTarget {
+    fn catalog_id(&self) -> &'static str {
+        "xai"
+    }
+
+    fn tool_id(&self) -> &'static str {
+        "grok"
+    }
+
+    fn live_path(&self) -> CustodyResult<PathBuf> {
+        skillstar_models::tool_sync::resolve_grok_auth_path().map_err(|error| {
+            CustodyError::ResolveLivePath {
+                tool: TOOL,
+                detail: error.to_string(),
+            }
+        })
+    }
+
+    /// Grok's own lock, not a private one: the CLI takes it before rotating,
+    /// so sharing it is what keeps a single-use refresh token from being spent
+    /// twice.
+    fn lock_path(&self, live: &Path) -> PathBuf {
+        live.with_extension("json.lock")
+    }
+
+    fn lock_holder_line(&self) -> bool {
+        true
+    }
+
+    fn access_token(&self, root: &Value) -> Option<String> {
+        self.entry(root)?
+            .get("key")
+            .and_then(Value::as_str)
+            .filter(|token| !token.is_empty())
+            .map(str::to_string)
+    }
+
+    fn expires_at(&self, root: &Value) -> Option<i64> {
+        let stored = self
+            .entry(root)
+            .and_then(|entry| entry.get("expires_at"))
+            .and_then(Value::as_str)
+            .and_then(|raw| DateTime::parse_from_rfc3339(raw).ok())
+            .map(|parsed| parsed.timestamp());
+        let jwt = self
+            .access_token(root)
+            .and_then(|token| token_refresh::jwt_exp(&token));
+        match (stored, jwt) {
+            (Some(stored), Some(jwt)) => Some(stored.min(jwt)),
+            (stored, jwt) => stored.or(jwt),
+        }
+    }
+
+    fn identity(&self, root: &Value) -> AccountIdentity {
+        let mut identity = AccountIdentity::default();
+        let Some(entry) = self.entry(root) else {
+            return identity;
+        };
+        for field in ["sub", "user_id", "principal_id"] {
+            identity.push_subject(entry.get(field).and_then(Value::as_str));
+        }
+        identity.push_email(entry.get("email").and_then(Value::as_str));
+        identity
+    }
+
+    fn materialize(
+        &self,
+        sub: &Subscription,
+        base: Option<&Value>,
+    ) -> Result<Value, MaterializeError> {
+        let access_token = secret(sub.access_token_encrypted.as_deref()).ok_or(
+            MaterializeError::MissingSecret {
+                tool: TOOL,
+                field: "access_token",
+                remedy: "请重新授权该账号",
+            },
+        )?;
+        check_cli_scopes(&access_token)?;
+
+        let mut root = base
+            .and_then(Value::as_object)
+            .cloned()
+            .unwrap_or_else(Map::new);
+        let scope = scope_key();
+        let mut entry = root
+            .get(&scope)
+            .and_then(Value::as_object)
+            .cloned()
+            .unwrap_or_else(Map::new);
+
+        entry.insert("key".into(), Value::String(access_token.clone()));
+        if let Some(refresh) = secret(sub.refresh_token_encrypted.as_deref()) {
+            entry.insert("refresh_token".into(), Value::String(refresh));
+        }
+        if let Some(expires_at) = subscription_expiry(sub).and_then(format_rfc3339) {
+            entry.insert("expires_at".into(), Value::String(expires_at));
+        }
+        // Identity fields carried over from *another* account's entry would
+        // make the new login answer to the old name. The same account's own
+        // fields are kept: they are CLI-private metadata (team, profile) that
+        // a rotated opaque token cannot reproduce.
+        if self
+            .identity(base.unwrap_or(&Value::Null))
+            .conflicts(&subscription_identity(sub))
+        {
+            for field in MIRRORED_CLAIMS {
+                entry.remove(field);
+            }
+        }
+        fill_schema(&mut entry, &access_token, sub);
+        require_restorable(&entry)?;
+
+        root.insert(scope, Value::Object(entry));
+        Ok(Value::Object(root))
+    }
+
+    fn absorb(&self, root: &Value, sub: &mut Subscription) {
+        let Some(entry) = self.entry(root) else {
+            return;
+        };
+        if let Some(token) = entry.get("key").and_then(Value::as_str) {
+            sub.access_token_encrypted = Some(crypto::encrypt(token));
+        }
+        sub.refresh_token_encrypted = entry
+            .get("refresh_token")
+            .and_then(Value::as_str)
+            .filter(|token| !token.is_empty())
+            .map(crypto::encrypt);
+        sub.access_token_expires_at = self.expires_at(root);
+        if let Some(user_id) = ["user_id", "principal_id", "sub"]
+            .into_iter()
+            .find_map(|field| entry.get(field).and_then(Value::as_str))
+            .filter(|value| !value.is_empty())
+        {
+            sub.oauth_account_id = Some(user_id.to_string());
+        }
+        sub.requires_reauth = false;
+    }
+}
+
+/// Bring an entry up to the shape the Grok CLI reads, without overwriting
+/// anything the CLI already put there.
+fn fill_schema(entry: &mut Map<String, Value>, access_token: &str, sub: &Subscription) {
+    entry
+        .entry("auth_mode")
+        .or_insert_with(|| Value::String("oidc".into()));
+    entry
+        .entry("oidc_issuer")
+        .or_insert_with(|| Value::String("https://auth.x.ai".into()));
+    entry.entry("oidc_client_id").or_insert_with(|| {
+        Value::String(skillstar_usage::fetchers::oauth::xai::client_id().into())
+    });
+
+    if let Some(claims) = token_refresh::decode_jwt_payload(access_token) {
+        for field in MIRRORED_CLAIMS {
+            if let Some(value) = claims.get(field).and_then(Value::as_str) {
+                entry
+                    .entry(field)
+                    .or_insert_with(|| Value::String(value.to_string()));
+            }
+        }
+        if let Some(subject) = claims.get("sub").and_then(Value::as_str) {
+            entry
+                .entry("user_id")
+                .or_insert_with(|| Value::String(subject.to_string()));
+        }
+        if let Some(opt_out) = claims
+            .get("coding_data_retention_opt_out")
+            .and_then(Value::as_bool)
+        {
+            entry
+                .entry("coding_data_retention_opt_out")
+                .or_insert(Value::Bool(opt_out));
+        }
+    }
+
+    let identity = subscription_identity(sub);
+    if let Some(email) = identity.email().map(str::to_string) {
+        entry.entry("email").or_insert(Value::String(email));
+    }
+    if let Some(subject) = identity.subject().map(str::to_string) {
+        entry
+            .entry("user_id")
+            .or_insert_with(|| Value::String(subject.clone()));
+        entry
+            .entry("principal_id")
+            .or_insert(Value::String(subject));
+    }
+    if entry.get("expires_at").is_none()
+        && let Some(expires_at) = token_refresh::jwt_exp(access_token).and_then(format_rfc3339)
+    {
+        entry.insert("expires_at".into(), Value::String(expires_at));
+    }
+
+    let email_prefix = entry
+        .get("email")
+        .and_then(Value::as_str)
+        .and_then(|email| email.split('@').next())
+        .unwrap_or_default()
+        .to_string();
+    entry
+        .entry("create_time")
+        .or_insert_with(|| Value::String(now_rfc3339()));
+    entry
+        .entry("first_name")
+        .or_insert_with(|| Value::String(email_prefix));
+    for field in ["last_name", "profile_image_asset_id", "team_id"] {
+        entry
+            .entry(field)
+            .or_insert_with(|| Value::String(String::new()));
+    }
+    entry
+        .entry("principal_type")
+        .or_insert_with(|| Value::String("user".into()));
+    entry
+        .entry("coding_data_retention_opt_out")
+        .or_insert(Value::Bool(false));
+}
+
+/// A synthesised entry must be complete enough that the CLI can restore a
+/// session from it — a half-formed one looks logged in and behaves logged out.
+fn require_restorable(entry: &Map<String, Value>) -> Result<(), MaterializeError> {
+    for field in [
+        "create_time",
+        "user_id",
+        "email",
+        "first_name",
+        "last_name",
+        "profile_image_asset_id",
+        "principal_type",
+        "principal_id",
+        "team_id",
+        "expires_at",
+    ] {
+        if entry.get(field).and_then(Value::as_str).is_none() {
+            return Err(MaterializeError::IncompleteEntry { tool: TOOL, field });
+        }
+    }
+    if !entry
+        .get("refresh_token")
+        .and_then(Value::as_str)
+        .is_some_and(|token| !token.trim().is_empty())
+    {
+        return Err(MaterializeError::MissingRefreshToken { tool: TOOL });
+    }
+    Ok(())
+}
+
+/// Opaque (non-JWT) tokens cannot be inspected; that is not evidence of a
+/// missing scope, so they pass. A readable token missing a CLI scope does not.
+fn check_cli_scopes(token: &str) -> Result<(), MaterializeError> {
+    let Some(claims) = token_refresh::decode_jwt_payload(token) else {
+        return Ok(());
+    };
+    let mut scopes = HashSet::new();
+    for key in ["scope", "scp"] {
+        match claims.get(key) {
+            Some(Value::String(raw)) => scopes.extend(raw.split_whitespace().map(str::to_string)),
+            Some(Value::Array(values)) => {
+                scopes.extend(values.iter().filter_map(Value::as_str).map(str::to_string));
+            }
+            _ => {}
+        }
+    }
+    let missing: Vec<String> = REQUIRED_CLI_SCOPES
+        .iter()
+        .filter(|required| !scopes.contains(**required))
+        .map(|required| (*required).to_string())
+        .collect();
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(MaterializeError::MissingCliScopes {
+            tool: TOOL,
+            missing,
+        })
+    }
+}
+
+fn format_rfc3339(seconds: i64) -> Option<String> {
+    DateTime::<Utc>::from_timestamp(seconds, 0)
+        .map(|date| date.format("%Y-%m-%dT%H:%M:%S%.6fZ").to_string())
+}
+
+fn now_rfc3339() -> String {
+    Utc::now().format("%Y-%m-%dT%H:%M:%S%.6fZ").to_string()
+}

--- a/crates/skillstar-app/src/usage_switch/target/opencode.rs
+++ b/crates/skillstar-app/src/usage_switch/target/opencode.rs
@@ -1,0 +1,119 @@
+//! OpenCode: `$XDG_DATA_HOME/opencode/auth.json`, a flat
+//! `providerID → credential` map at 0600 — the file `opencode auth login`
+//! writes and the only one OpenCode's paid-model gate reads.
+//!
+//! Under custody this catalog stops needing an `api_key_encrypted` at all.
+//! OpenCode's catalog auth modes are Cookie|Manual, so the old "project the
+//! subscription's API key into the CLI" path could never fire — the switch
+//! entry was permanently dead. Capturing the credential the CLI already holds
+//! decouples "can this account be switched to" from "how did SkillStar
+//! authenticate to read its usage".
+
+use std::path::PathBuf;
+
+use serde_json::{Map, Value};
+use skillstar_usage::crypto;
+use skillstar_usage::subscription::Subscription;
+
+use super::super::error::{CustodyError, CustodyResult, MaterializeError};
+use super::{AccountIdentity, CliCredentialTarget, secret};
+
+/// What the user calls this CLI, for messages the user reads. `tool_id` stays
+/// lowercase because the UI keys off it.
+const TOOL: &str = "OpenCode";
+
+/// OpenCode's own provider id for its first-party (Zen) service. A literal,
+/// not a SkillStar-chosen name: `provider.ts` gates paid models on
+/// `auth.json["opencode"]` and nothing else.
+const PROVIDER_KEY: &str = "opencode";
+
+pub(in crate::usage_switch) struct OpenCodeTarget;
+
+impl OpenCodeTarget {
+    fn credential<'a>(&self, root: &'a Value) -> Option<&'a Value> {
+        root.get(PROVIDER_KEY)
+    }
+}
+
+impl CliCredentialTarget for OpenCodeTarget {
+    fn catalog_id(&self) -> &'static str {
+        "opencode"
+    }
+
+    fn tool_id(&self) -> &'static str {
+        "opencode"
+    }
+
+    fn live_path(&self) -> CustodyResult<PathBuf> {
+        skillstar_models::tool_sync::resolve_opencode_auth_path().map_err(|error| {
+            CustodyError::ResolveLivePath {
+                tool: TOOL,
+                detail: error.to_string(),
+            }
+        })
+    }
+
+    fn access_token(&self, root: &Value) -> Option<String> {
+        let credential = self.credential(root)?;
+        ["key", "access", "token"]
+            .into_iter()
+            .find_map(|field| credential.get(field).and_then(Value::as_str))
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+    }
+
+    /// Upstream stores OAuth expiry as epoch **milliseconds**; API keys have none.
+    fn expires_at(&self, root: &Value) -> Option<i64> {
+        let millis = self.credential(root)?.get("expires")?.as_i64()?;
+        Some(millis / 1000)
+    }
+
+    /// OpenCode credentials carry no claims at all — no subject, no email.
+    /// An empty identity is "unknown", which never conflicts, so capture can
+    /// still attribute a session to the account the user is activating.
+    fn identity(&self, _root: &Value) -> AccountIdentity {
+        AccountIdentity::default()
+    }
+
+    fn materialize(
+        &self,
+        sub: &Subscription,
+        base: Option<&Value>,
+    ) -> Result<Value, MaterializeError> {
+        let api_key = secret(sub.api_key_encrypted.as_deref())
+            .ok_or(MaterializeError::NoCapturedSession { tool: TOOL })?;
+        let mut root = base
+            .and_then(Value::as_object)
+            .cloned()
+            .unwrap_or_else(Map::new);
+        root.insert(
+            PROVIDER_KEY.into(),
+            serde_json::json!({ "type": "api", "key": api_key }),
+        );
+        Ok(Value::Object(root))
+    }
+
+    fn absorb(&self, root: &Value, sub: &mut Subscription) {
+        let Some(credential) = self.credential(root) else {
+            return;
+        };
+        match credential.get("type").and_then(Value::as_str) {
+            Some("oauth") => {
+                if let Some(access) = credential.get("access").and_then(Value::as_str) {
+                    sub.access_token_encrypted = Some(crypto::encrypt(access));
+                }
+                sub.refresh_token_encrypted = credential
+                    .get("refresh")
+                    .and_then(Value::as_str)
+                    .filter(|value| !value.is_empty())
+                    .map(crypto::encrypt);
+                sub.access_token_expires_at = self.expires_at(root);
+            }
+            _ => {
+                if let Some(key) = self.access_token(root) {
+                    sub.api_key_encrypted = Some(crypto::encrypt(&key));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 问题

`.gitignore` 里的 `target/` 没有前导斜杠，Git 会把它匹配到**任意深度**的 `target` 目录。`crates/skillstar-app/src/usage_switch/target/` 是一个源码目录，因此被静默忽略，它的三个 module 从未进过版本库。

`usage_switch/target.rs` 声明了这三个 module，所以 `main` 自这些文件写下起就编译不过：

- CI 自 2026-08-16 起持续失败，`test-linux` 与 `test-macos` 都报 `E0583: file not found for module` —— `codex` / `grok` / `opencode`。最后一次绿是 2026-08-03。
- 全新 clone 无法构建。

## 修复

把规则锚定到工作区根目录。`src-tauri/target/` 保留它自己那一行，磁盘上真正的构建目录只有根 `./target`，所以不会有本该被忽略的东西开始被跟踪。

同时补交这三个源文件（共 649 行，无 `todo!` / `unimplemented!`）。

## 验证

- `cargo check --workspace --locked` 在干净 worktree 上从失败（exit 101）变为通过（exit 0）。
- 全部 pre-commit ratchet 通过（含 biome）。
- 已扫描三个文件，无字面量密钥；它们是处理凭据文件路径与读写逻辑的正常源码。

## 说明

这是 #33 系列工作的前置：没有它，任何从 main 起的分支都无法验证。发现于 `/implement-spec` 的基线检查。

🤖 Generated with [Claude Code](https://claude.com/claude-code)